### PR TITLE
Add Dropbox uploader support and fix file deletion issue

### DIFF
--- a/CTFd/api/v1/files.py
+++ b/CTFd/api/v1/files.py
@@ -61,6 +61,7 @@ class FilesDetail(Resource):
     def delete(self, file_id):
         f = Files.query.filter_by(id=file_id).first_or_404()
 
+        uploads.delete_file(file_id=f.id)
         db.session.delete(f)
         db.session.commit()
         db.session.close()

--- a/CTFd/config.py
+++ b/CTFd/config.py
@@ -190,6 +190,12 @@ class Config(object):
     AWS_S3_ENDPOINT_URL:
         A URL pointing to a custom S3 implementation.
 
+    DROPBOX_OAUTH2_TOKEN:
+        Dropbox secret token.
+
+    DROPBOX_ROOT_PATH:
+        The dropbox root path to store files. Default to /CTFd
+
     """
     UPLOAD_PROVIDER = os.getenv("UPLOAD_PROVIDER") or "filesystem"
     UPLOAD_FOLDER = os.getenv("UPLOAD_FOLDER") or os.path.join(
@@ -200,7 +206,9 @@ class Config(object):
         AWS_SECRET_ACCESS_KEY = os.getenv("AWS_SECRET_ACCESS_KEY")
         AWS_S3_BUCKET = os.getenv("AWS_S3_BUCKET")
         AWS_S3_ENDPOINT_URL = os.getenv("AWS_S3_ENDPOINT_URL")
-
+    elif UPLOAD_PROVIDER == "dropbox":
+        DROPBOX_OAUTH2_TOKEN = os.getenv("DROPBOX_OAUTH2_TOKEN")
+        DROPBOX_ROOT_PATH = os.getenv("DROPBOX_ROOT_PATH") or "/CTFd"
     """
     === OPTIONAL ===
 

--- a/CTFd/utils/uploads/__init__.py
+++ b/CTFd/utils/uploads/__init__.py
@@ -2,9 +2,13 @@ import shutil
 
 from CTFd.models import ChallengeFiles, Files, PageFiles, db
 from CTFd.utils import get_app_config
-from CTFd.utils.uploads.uploaders import FilesystemUploader, S3Uploader
+from CTFd.utils.uploads.uploaders import FilesystemUploader, S3Uploader, DropboxUploader
 
-UPLOADERS = {"filesystem": FilesystemUploader, "s3": S3Uploader}
+UPLOADERS = {
+    "filesystem": FilesystemUploader,
+    "s3": S3Uploader,
+    "dropbox": DropboxUploader,
+}
 
 
 def get_uploader():

--- a/CTFd/utils/uploads/uploaders.py
+++ b/CTFd/utils/uploads/uploaders.py
@@ -4,6 +4,10 @@ import string
 from shutil import copyfileobj
 
 import boto3
+
+from dropbox import Dropbox
+from dropbox.files import FolderMetadata, WriteMode
+
 from flask import current_app, redirect, send_file
 from flask.helpers import safe_join
 from werkzeug.utils import secure_filename
@@ -146,3 +150,72 @@ class S3Uploader(BaseUploader):
                     os.makedirs(directory)
 
                 self.s3.download_file(self.bucket, s3_object, local_path)
+
+
+class DropboxUploader(BaseUploader):
+    def __init__(self):
+        super(BaseUploader, self).__init__()
+        self.oauth2_access_token = get_app_config("DROPBOX_OAUTH2_TOKEN")
+        self.root_path = get_app_config("DROPBOX_ROOT_PATH")
+        self.client = Dropbox(self.oauth2_access_token, timeout=100)
+        self.write_mode = "add"  # can be overwrite
+
+    def _clean_filename(self, c):
+        if c in string.ascii_letters + string.digits + "-" + "_" + ".":
+            return True
+
+    def _full_path(self, name):
+        return safe_join(self.root_path, name).replace("\\", "/")
+
+    def store(self, fileobj, filename):
+        self.client.files_upload(
+            fileobj.read(), self._full_path(filename), mode=WriteMode(self.write_mode)
+        )
+        return filename
+
+    def upload(self, file_obj, filename):
+        filename = filter(
+            self._clean_filename, secure_filename(filename).replace(" ", "_")
+        )
+        filename = "".join(filename)
+        if len(filename) <= 0:
+            return False
+
+        md5hash = hexencode(os.urandom(16))
+
+        dst = md5hash + "/" + filename
+        self.store(file_obj, dst)
+        return dst
+
+    def download(self, filename):
+        media = self.client.files_get_temporary_link(self._full_path(filename))
+        print(media.link)
+        return redirect(media.link)
+
+    def delete(self, filename):
+        directory = os.path.dirname(self._full_path(filename))
+        self.client.files_delete(directory)
+        return True
+
+    def sync(self):
+        local_folder = current_app.config.get("UPLOAD_FOLDER")
+
+        root_metadata = self.client.files_list_folder(self.root_path)
+
+        for folder_entry in root_metadata.entries:
+            if isinstance(folder_entry, FolderMetadata):
+                filemetadata = self.client.files_list_folder(folder_entry.path_lower)
+                for file_entry in filemetadata.entries:
+                    if not isinstance(file_entry, FolderMetadata):
+
+                        dropbox_path = file_entry.path_lower.replace(
+                            self.root_path.lower() + "/", ""
+                        )
+                        local_path = os.path.join(local_folder, dropbox_path)
+                        directory = os.path.dirname(local_path)
+                        if not os.path.exists(directory):
+                            os.makedirs(directory)
+
+                        self.client.files_download_to_file(
+                            local_path, file_entry.path_lower
+                        )

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ CTFd is a Capture The Flag framework focusing on ease of use and customizability
     * Static & Regex based flags
         * Custom flag plugins
     * Unlockable hints
-    * File uploads to the server or an Amazon S3-compatible backend
+    * File uploads to the server, an Amazon S3-compatible backend or Dropbox
     * Limit challenge attempts & hide challenges
     * Automatic bruteforce protection
 * Individual and Team based competitions

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -104,6 +104,14 @@ AWS_S3_ENDPOINT_URL
 ~~~~~~~~~~~~~~~~~~~
 A URL pointing to a custom S3 implementation.
 
+DROPBOX_OAUTH2_TOKEN:
+~~~~~~~~~~~~~~~~~~~
+Dropbox secret token.
+
+DROPBOX_ROOT_PATH:
+~~~~~~~~~~~~~~~~~~~
+The dropbox root path to store files. Default to /CTFd
+
 
 REVERSE_PROXY
 ~~~~~~~~~~~~~

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ flask-marshmallow==0.10.1
 marshmallow-sqlalchemy==0.17.0
 boto3==1.10.39
 marshmallow==2.20.2
+dropbox==10.1.2


### PR DESCRIPTION
Add Dropbox uploader backend support to store files using Dropbox API. 

To use it you need to generate a
_oauth2 token_ following the [Dropbox API tutorial](https://www.dropbox.com/developers/documentation/python#tutorial), set it to the `DROPBOX_OAUTH2_TOKEN`  variable and set `UPLOAD_PROVIDER`  to `dropbox`

You can specify the `DROPBOX_ROOT_PATH`, by default will be /CTFd

Also fixed an issue in CTFd API: CTFd/api/v1/files.py was not deleting files.